### PR TITLE
invalid file descriptor passed

### DIFF
--- a/tests/libevent008.phpt
+++ b/tests/libevent008.phpt
@@ -1,0 +1,22 @@
+--TEST--
+pecl/libevent - bug https://github.com/expressif/pecl-event-libevent/issues/18
+--SKIPIF--
+<?php
+if (!extension_loaded("libevent")) die("skip pecl/libevent needed");
+--FILE--
+<?php
+$base = event_base_new();
+
+// first event reader
+$event = event_new();
+var_dump(event_set($event, 0, EV_TIMEOUT,function(){
+}));
+
+event_base_set($event, $base);
+var_dump(event_add($event, 5000000));
+event_base_loop($base);
+
+?>
+--EXPECTF--
+bool(true)
+bool(true)


### PR DESCRIPTION
See https://github.com/walkor/Workerman/blob/master/Events/Libevent.php#L84 , the 2th argument of ```event_set``` is 0 that is integer not resource , I see http://php.net/manual/en/function.event-set.php and 2th argument is mixed and Signal number or resource indicating the stream.  but with expressif/pecl-event-libevent we have this error ```PHP Warning:  event_set(): invalid file descriptor passed ```