### PR TITLE
Support PHP8

### DIFF
--- a/libevent.c
+++ b/libevent.c
@@ -376,7 +376,7 @@ static PHP_FUNCTION(event_base_reinit) {
 
     r = event_reinit(base->base);
     if (r == -1) {
-        RETURN_FALSE
+        RETURN_FALSE;
     } else {
         RETURN_TRUE;
     }
@@ -683,7 +683,7 @@ static PHP_FUNCTION(event_set)
 	} else {
 
 		if (Z_TYPE_P(fd) == IS_LONG) {
-			fd = zend_hash_index_find(&EG(regular_list), Z_RES_P(fd));
+			fd = zend_hash_index_find(&EG(regular_list), (zend_ulong) Z_RES_P(fd));
 			if (!fd) {
 				php_error_docref(NULL, E_WARNING, "invalid file descriptor passed");
 				RETURN_FALSE;
@@ -922,7 +922,7 @@ static PHP_FUNCTION(event_buffer_new)
 	}
 
 	if (Z_TYPE_P(zfd) == IS_LONG) {
-		zfd = zend_hash_index_find(&EG(regular_list), Z_RES_P(zfd));
+		zfd = zend_hash_index_find(&EG(regular_list), (zend_ulong) Z_RES_P(zfd));
 		if (!zfd) {
 			php_error_docref(NULL, E_WARNING, "invalid file descriptor passed");
 			RETURN_FALSE;
@@ -1298,7 +1298,7 @@ static PHP_FUNCTION(event_buffer_fd_set)
 		RETURN_FALSE;
 
 	if (Z_TYPE_P(zfd) == IS_LONG) {
-		zfd = zend_hash_index_find(&EG(regular_list), Z_RES_P(zfd));
+		zfd = zend_hash_index_find(&EG(regular_list), (zend_ulong) Z_RES_P(zfd));
 		if (!zfd) {
 			php_error_docref(NULL, E_WARNING, "invalid file descriptor passed");
 			RETURN_FALSE;

--- a/php_libevent.h
+++ b/php_libevent.h
@@ -27,8 +27,14 @@
 extern zend_module_entry libevent_module_entry;
 #define phpext_libevent_ptr &libevent_module_entry
 
-#ifdef ZTS
 #include "TSRM.h"
+
+/*
+ * Removed from PHP8.
+ */
+#if PHP_VERSION_ID >= 80000
+#  define TSRMLS_FETCH_FROM_CTX(ctx)
+#  define TSRMLS_SET_CTX(ctx)
 #endif
 
 #ifndef zend_always_inline


### PR DESCRIPTION
## PHP 8 support
- Fixed a problem that failed due to TSRM CONSTANT removed from PHP 8 
- Modify the Miss Casting Warning of the second argument of Zend_Hash_INDEX_FIND 
- All pass result of **make test**
    ```
    =====================================================================
    PHP         : /usr/bin/php80
    PHP_SAPI    : cli
    PHP_VERSION : 8.0.3
    ZEND_VERSION: 4.0.3
    PHP_OS      : Linux - Linux AnNyung build
    INI actual  : /root/work/github/libevent/tmp-php.ini
    More .INIs  :
    CWD         : /root/work/github/libevent
    Extra dirs  :
    VALGRIND    : Not used
    =====================================================================
    TIME START 2021-03-13 19:33:32
    =====================================================================
    PASS pecl/libevent - general [tests/libevent001.phpt]
    PASS pecl/libevent - bug https://github.com/expressif/pecl-event-libevent/issues/2 [tests/libevent002.phpt]
    PASS pecl/libevent - bug https://github.com/expressif/pecl-event-libevent/issues/3 [tests/libevent003.phpt]
    PASS pecl/libevent - bug https://github.com/expressif/pecl-event-libevent/issues/9 [tests/libevent004.phpt]
    PASS pecl/libevent - bug https://github.com/expressif/pecl-event-libevent/issues/8 [tests/libevent005.phpt]
    PASS pecl/libevent - bug https://github.com/expressif/pecl-event-libevent/issues/8 [tests/libevent006.phpt]
    PASS pecl/libevent - bug https://github.com/expressif/pecl-event-libevent/issues/14 [tests/libevent007.phpt]
    PASS pecl/libevent - bug https://github.com/expressif/pecl-event-libevent/issues/19 [tests/libevent008.phpt]
    =====================================================================
    TIME END 2021-03-13 19:33:39

    =====================================================================
    TEST RESULT SUMMARY
    ---------------------------------------------------------------------
    Exts skipped    :    0
    Exts tested     :   34
    ---------------------------------------------------------------------

    Number of tests :    8                 8
    Tests skipped   :    0 (  0.0%) --------
    Tests warned    :    0 (  0.0%) (  0.0%)
    Tests failed    :    0 (  0.0%) (  0.0%)
    Tests passed    :    8 (100.0%) (100.0%)
    ---------------------------------------------------------------------
    Time taken      :    7 seconds
    =====================================================================
    ```